### PR TITLE
Fix Sparkle signing migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,13 @@ Automatic updates use Sparkle and are driven by
    stores a private key in your login Keychain and prints a public key.
 2. Paste that public key into `Info.plist` → `SUPublicEDKey`, and commit.
 
+Ship the public key in a release that keeps the previous Apple code-signing
+identity. Existing installations do not trust a newly added Sparkle key until
+they have installed it once. If the Apple code-signing identity must change at
+the same time, first publish a bridge update signed with the old identity and
+containing the new public key. Add `sparkle:minimumAutoupdateVersion` to the
+later update so older builds install the bridge first.
+
 **Each release**
 
 1. Bump `MARKETING_VERSION` and `CURRENT_PROJECT_VERSION` in the project.

--- a/appcast.xml
+++ b/appcast.xml
@@ -25,12 +25,25 @@
       <title>Tactile 1.0.4</title>
       <pubDate>Mon, 13 Jul 2026 00:00:00 +0000</pubDate>
       <sparkle:minimumSystemVersion>14.6</sparkle:minimumSystemVersion>
+      <sparkle:minimumAutoupdateVersion>4</sparkle:minimumAutoupdateVersion>
       <description><![CDATA[<p>Tactile is now notarized by Apple: it opens without the Gatekeeper warning, no need to clear quarantine. Updates are also signed with Sparkle's EdDSA key from this release on.</p>]]></description>
       <enclosure url="https://github.com/Mason363/Tactile/releases/download/v1.0.4/Tactile-1.0.4.zip"
                  sparkle:version="5"
                  sparkle:shortVersionString="1.0.4"
                  length="3084069"
                  sparkle:edSignature="FYR7rJRHYLjRNgsKkFcrG7p9s0DDzYegNwuK1rfOP0Dptn06Q494PAGFShPbNHscOmZ6nafBPJngPMnTDyx8Bg=="
+                 type="application/octet-stream" />
+    </item>
+    <item>
+      <title>Tactile 1.0.3 signing bridge</title>
+      <pubDate>Sat, 18 Jul 2026 00:00:00 +0000</pubDate>
+      <sparkle:minimumSystemVersion>14.6</sparkle:minimumSystemVersion>
+      <description><![CDATA[<p>Installs Tactile's Sparkle public key using the code-signing identity trusted by Tactile 1.0.2, then allows the signed Tactile 1.0.4 update.</p>]]></description>
+      <enclosure url="https://github.com/Mason363/Tactile/releases/download/v1.0.4/Tactile-1.0.3-bridge.zip"
+                 sparkle:version="4"
+                 sparkle:shortVersionString="1.0.3"
+                 length="3054678"
+                 sparkle:edSignature="uNrXytYTw55y2jHicOQ4OVXPnnDP1nmV/S7Bdfup6jTv6D3KXCq2JgF9z9Q3E+QQRQSnaTIDCAS33591HZmhDg=="
                  type="application/octet-stream" />
     </item>
     <item>


### PR DESCRIPTION
## What changed

- add an Apple Development-signed Tactile 1.0.3 bridge update containing the Sparkle EdDSA public key
- gate the notarized Tactile 1.0.4 item with `sparkle:minimumAutoupdateVersion` so build 3 installs bridge build 4 first
- document the required trust-preserving release sequence

## Root cause

Tactile 1.0.2 did not contain `SUPublicEDKey`. Tactile 1.0.4 changed from the Apple Development identity trusted by 1.0.2 to Developer ID signing. The old updater therefore had neither a matching code-signing identity nor a previously trusted EdDSA key with which to validate the update.

## User impact

Tactile 1.0.2 now updates to the signing bridge, then to the existing notarized Tactile 1.0.4 release. Fresh installs remain on the notarized release path.

## Validation

- verified the published 1.0.4 asset size and SHA-256 against the local archive
- verified both Sparkle EdDSA signatures with `sign_update --verify`
- verified the bridge app matches 1.0.2's exact Apple Development designated requirement
- verified the published 1.0.4 app is valid but does not match that old requirement, reproducing the trust break
- linked a temporary harness against Sparkle 2.9.3 and confirmed build 3 selects build 4, then build 4 selects build 5
- validated `appcast.xml` with `xmllint`

Fixes #1